### PR TITLE
Fix Responsiveness of Images

### DIFF
--- a/page/partials/advisors.ejs
+++ b/page/partials/advisors.ejs
@@ -1,4 +1,4 @@
-<div class="advisors section">
+<div class="section advisors">
         <div class="row">
             <div class="col-md-5">
                 <div class="has-carousel lazyLoad">

--- a/page/partials/team.ejs
+++ b/page/partials/team.ejs
@@ -1,4 +1,4 @@
-<div class="team section">
+<div class="section team">
     <div class="row">
         <div class="col-md-4">
             <div>

--- a/page/sass/advisors.scss
+++ b/page/sass/advisors.scss
@@ -1,4 +1,5 @@
 .advisors{
+  padding-bottom: 0px;
     p{
         width: 426px;
         font-style: italic;
@@ -8,7 +9,7 @@
     }
     .h4.position{
         font-weight: $font-weight-normal;
-    }    
+    }
 }
 
 .has-carousel{
@@ -39,4 +40,3 @@
 .owl-nav{
     display: none;
 }
-

--- a/page/sass/common.scss
+++ b/page/sass/common.scss
@@ -4,10 +4,11 @@ body{
 
 .person-info-container{
     margin-bottom: $padding-between-pictures;
-    
+
     .person-info .person-details{
-        float: left;
-        margin-top: 27px;
+        margin-top: -62px;
+        margin-left: 105px;
+        margin-bottom: 29px;
     }
 }
 
@@ -15,12 +16,12 @@ body{
     position: relative;
     padding-top: $padding-between-sections;
     padding-bottom: $padding-between-sections;
-    border-bottom: 1px $off-white solid;  
+    border-bottom: 1px $off-white solid;
 
     .see-more{
-        position: absolute;    
+        position: absolute;
         right: 50px;
-        bottom: 0;        
+        bottom: 0;
         background: none;
         border: 0px;
         color: $blue;
@@ -28,7 +29,7 @@ body{
         transition:all 1s;
     }
 
-    .hidden-picture{            
+    .hidden-picture{
         display: none;
     }
     .person-info h4{
@@ -54,18 +55,18 @@ body{
     a{
         font-weight: $font-weight-more-bold;
     }
-    button.btn.btn-white {       
+    button.btn.btn-white {
         background: white;
-        color: #09719B;        
+        color: #09719B;
         height: 40px;
         padding: 5px 45px 5px 45px;
         box-shadow: 0 1px 1px 0 rgba(163,192,204,0.31);
         border: 1px solid #09719B;
     }
-    
-    p.intro{        
+
+    p.intro{
         font-weight: $font-weight-normal;
-    }    
+    }
 
     .pictures-container{
         padding-top: $padding-between-sections;
@@ -85,7 +86,7 @@ body{
     display: inline-block;
 
     .hexagon-blue {
-        background-color: $blue-darker; 
+        background-color: $blue-darker;
     }
     .hexagon-white-green {
         background-color: $white-green;

--- a/page/sass/pictures.scss
+++ b/page/sass/pictures.scss
@@ -2,6 +2,5 @@ img.rounded-image{
     width: 92px;
     height: 92px;
     border-radius: 50%;
-    float: left;
     margin-right: 15px;
 }

--- a/page/sass/team.scss
+++ b/page/sass/team.scss
@@ -1,4 +1,5 @@
-.team.section{
+.team{
+  padding-bottom: 0px;
     h4.position{
         font-weight: $font-weight-light;
     }


### PR DESCRIPTION
Fix issue in partial/advisors
Fix issue in partial/team
Change style for Advisors,Team

The biggest issue with responsiveness was floating, in Bootstrap floating components is very risky and unpredictable if all cases are not taken care of for different screens. 
A better trick i suggest is using negative margin to achieve the desired effect. currently the pictures show up very similar and at the same time with a nice symmetrical small view attached images below
![image](https://user-images.githubusercontent.com/23242822/29480743-de5cfd7a-847a-11e7-8452-0c9fb79a3b00.png)
![commit team](https://user-images.githubusercontent.com/23242822/29480770-20de7070-847b-11e7-85a1-480cb4fd1021.png)
