### PR TITLE
change icom instruction to icomonitor link

### DIFF
--- a/app/components/AfterIcoSumup.tsx
+++ b/app/components/AfterIcoSumup.tsx
@@ -25,6 +25,18 @@ export const AfterIcoSumup = (props: IAfterIcoSumupProps) => {
           Neufund is an investment platform bridging the worlds of blockchain and venture capital.
         </p>
 
+        <ul className="links-list">
+          <li>
+            <i className="material-icons">link</i>
+            <a
+              href="https://icomonitor.io/#/0xf432cec23b2a0d6062b969467f65669de81f4653"
+              target="_blank"
+            >
+              ICBM details in the ICO Transparency Monitor
+            </a>
+          </li>
+        </ul>
+
         <MailchimpForm />
       </Col>
       <Col sm={7} xsHidden>


### PR DESCRIPTION
On post-preICBM and post-ICBM page add link to icomonitor.io

![screen shot 2017-11-15 at 2 20 31 pm](https://user-images.githubusercontent.com/1808867/32838153-51b11e2a-ca10-11e7-80a4-090f69f01fa3.png)
