### PR TITLE
Increase puppeteer timeout to 40000 - same as mocha

### DIFF
--- a/test-e2e/puppeter.ts
+++ b/test-e2e/puppeter.ts
@@ -12,6 +12,7 @@ before(async () => {
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
     ignoreHTTPSErrors: true,
     headless: !config.puppeteerDebug,
+    timeout: 40000,
   });
 
   puppeteerInstance = browser;


### PR DESCRIPTION
After increasing mocha timeout from 20s to 40s now we have timeouts on puppeteer. I set same timeout as for mocha.